### PR TITLE
Fix typing declaration.

### DIFF
--- a/packages/auf-typing/src/index.ts
+++ b/packages/auf-typing/src/index.ts
@@ -13,8 +13,8 @@ export interface IContext {
   req: http.IncomingMessage;
   res: http.ServerResponse;
   serverOptions: IServerOptions;
-  body?: string | Readable | Record<string, any>;
-  extendInfo?: Record<string, any>;
+  body: string | Readable | Record<string, any>;
+  extendInfo: Record<string, any>;
   get reqBody(): Record<string, any>;
   get query(): Record<string, string>;
   get params(): Record<string, string>; 

--- a/packages/middlewares/src/__tests__/timeout.spec.ts
+++ b/packages/middlewares/src/__tests__/timeout.spec.ts
@@ -32,7 +32,7 @@ describe('[Timeout @@ middlewares] Normal Test', () => {
       setTimeout(resolve, time);
     });
     
-    TimeoutMiddleware(fakeContext, () => sleep(4000)).then(() => {
+    TimeoutMiddleware(fakeContext as any, () => sleep(4000)).then(() => {
       const body = JSON.parse(fakeContext.body);
       expect(body.success).toEqual(false);
       expect(body.message).toBe(`Request timeout, proceeded ${Config.timeout} ms`)
@@ -51,7 +51,7 @@ describe('[Timeout @@ middlewares] Normal Test', () => {
       }, time);
     });
     
-    TimeoutMiddleware(fakeContext, () => sleep(500)).then(() => {
+    TimeoutMiddleware(fakeContext as any, () => sleep(500)).then(() => {
       const body = JSON.parse(fakeContext.body);
       expect(body.success).toEqual(true);
       expect(body.data).toEqual(1);
@@ -71,7 +71,7 @@ describe('[Timeout @@ middlewares] Default Config Test', () => {
       }, time);
     });
     
-    TimeoutMiddleware(fakeContext, () => sleep(15500)).then(() => {
+    TimeoutMiddleware(fakeContext as any, () => sleep(15500)).then(() => {
       const body = JSON.parse(fakeContext.body);
       expect(body.success).toEqual(false);
       expect(body.message).toBe(`Request timeout, proceeded ${15000} ms`)


### PR DESCRIPTION
- Set IContext's `body` and `extendInfo` property to required.